### PR TITLE
[DRILL-4294] InfoSchema is not returning column metadata if the query…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
@@ -146,7 +146,15 @@ public class InfoSchemaFilter {
       case "like": {
         FieldExprNode arg0 = (FieldExprNode) exprNode.args.get(0);
         ConstantExprNode arg1 = (ConstantExprNode) exprNode.args.get(1);
+        ConstantExprNode arg2 = null;
+        if (exprNode.args.size() > 2 && exprNode.args.get(2) != null) {
+          arg2 = (ConstantExprNode) exprNode.args.get(2);
+        }
         if (recordValues.get(arg0.field.toString()) != null) {
+          if (arg2 != null) {
+            return Pattern.matches(RegexpUtil.sqlToRegexLike(arg1.value,arg2.value), 
+                recordValues.get(arg0.field.toString())) ? Result.TRUE : Result.FALSE;
+          }
           return Pattern.matches(RegexpUtil.sqlToRegexLike(arg1.value), recordValues.get(arg0.field.toString())) ?
               Result.TRUE : Result.FALSE;
         }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilterBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilterBuilder.java
@@ -73,8 +73,14 @@ public class InfoSchemaFilterBuilder extends AbstractExprVisitor<ExprNode, Void,
       case "like": {
         ExprNode arg0 = call.args.get(0).accept(this, value);
         ExprNode arg1 = call.args.get(1).accept(this, value);
-
+        ExprNode arg2 = null;
+        if (call.args.size() > 2 && call.args.get(2) != null) {
+          arg2 = call.args.get(2).accept(this, value);
+        }
         if (arg0 != null && arg0 instanceof FieldExprNode && arg1 != null && arg1 instanceof ConstantExprNode) {
+          if (arg2 != null && arg2 instanceof ConstantExprNode) {
+            return new FunctionExprNode(funcName, ImmutableList.of(arg0, arg1, arg2));
+          }
           return new FunctionExprNode(funcName, ImmutableList.of(arg0, arg1));
         }
         break;


### PR DESCRIPTION
… contains escape character

This was found while using Power BI.
1. Created a VIEW containing '_' backed by a csv file.
2. Connected to Power BI and it failed to load the data since the query
became erronous i.e. ' from table_name'
This is because power bi didn't get any column metadata from it's
previous query which contained ,
FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_CATALOG LIKE 'DRILL' ESCAPE
'\' AND TABLE_SCHEMA LIKE 'dfs.tmp' ESCAPE '\' AND TABLE_NAME LIKE
'app_client_\view' ESCAPE '\' ORDER BY TABLE_CATALOG, TABLE_SCHEMA,
TABLE_NAME, ORDINAL_POSITION, COLUMN_NAME

are the changes in right place if we want to accept schema filter?
e.g. 
"expr" : "booleanAnd(like(`TABLE_CATALOG`, 'DRILL', '\') , like(`TABLE_SCHEMA`, 'dfs.tmp', '\') , like(`TABLE_NAME`, 'app\_client\_view', '\') ) "
